### PR TITLE
DMD2.070 Deprecation - Use stdio.File instead of std.stream

### DIFF
--- a/src/dini.d
+++ b/src/dini.d
@@ -6,7 +6,7 @@
  */
 module dini;
 
-import std.stream : BufferedFile;
+import std.stdio : File;
 import std.string : strip;
 import std.traits : isSomeString;
 import std.array  : split, replaceInPlace, join;
@@ -311,12 +311,13 @@ struct IniSection
      */
     public void parse(string filename, bool doLookups = true)
     {
-        BufferedFile file = new BufferedFile(filename);
+        auto file = new File(filename);
         scope(exit) file.close;
         
         IniSection* section = &this;
-        
-        foreach(i, char[] line; file)
+
+        import std.range : enumerate;
+        foreach(i, char[] line; file.byLine.enumerate(1))
         {
             line = strip(line);
             


### PR DESCRIPTION
The release of 2.070 deprecated std.stream. These changes are to read a file without using std.stream.BufferedFile.

Please tag a new version when this is merged.