### PR TITLE
Forward the file/line of the thrown exception

### DIFF
--- a/src/dini.d
+++ b/src/dini.d
@@ -544,8 +544,8 @@ alias IniSection Ini;
 ///
 class IniException : Exception
 {
-    this(string msg)
+    this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
     {
-        super(msg);
+        super(msg, file, line, next);
     }
 }


### PR DESCRIPTION
This places the line number of an exception on the line that throws the exception, instead of the exception definition.