### PR TITLE
Add function that inserts INI data into struct

### DIFF
--- a/src/dini.d
+++ b/src/dini.d
@@ -606,6 +606,27 @@ EOF";
 /// ditto
 alias IniSection Ini;
 
+Struct siphon(Struct)(Ini ini) {
+	import std.traits;
+	Struct ans;
+	if(ini.hasSection(Struct.stringof))
+		foreach(ti, Name; FieldNameTuple!(Struct))
+		{
+			alias ToType = typeof(ans.tupleof[ti]);
+			if(ini[Struct.stringof].hasKey(Name))
+				ans.tupleof[ti] = to!ToType(ini[Struct.stringof].getKey(Name));
+		}
+	return ans;
+} unittest {
+	struct Section {
+		int var;
+	}
+
+	auto ini = Ini.ParseString("[Section]\nvar=3");
+	auto m = ini.siphon!Section;
+	assert(m.var == 3);
+}
+
 ///
 class IniException : Exception
 {


### PR DESCRIPTION
This is a very basic function that will insert the INI settings into a structure. The structure name should match the section and the fields should match the INI key. Data types are converted.

You may want to change the name of the function.